### PR TITLE
Milestone 1.0 release fixes

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -205,8 +205,8 @@
             <span class="anchor-hint">#</span>
           </a></h2>
           <p>
-            Een vlugge <a href="https://nl.wikipedia.org/wiki/Lakmoes">lakmoesproef</a> of je ruwweg <em>The Infi Way</em> volgt.
-            Een soort <a href="https://www.joelonsoftware.com/2000/08/09/the-joel-test-12-steps-to-better-code/">Joel Test</a>.
+            Een vlugge <a href="https://nl.wikipedia.org/wiki/Lakmoes" target="_blank">lakmoesproef</a> of je ruwweg <em>The Infi Way</em> volgt.
+            Een soort <a href="https://www.joelonsoftware.com/2000/08/09/the-joel-test-12-steps-to-better-code/" target="_blank">Joel Test</a>.
           </p>
           <ol>
             <li class="topic-gebruikers">Zien developers échte gebruikers?</li>
@@ -254,12 +254,12 @@
             <p>Denk aan <em>bijvoorbeeld</em>:</p>
             <ul>
               <li>Gebruikerstests</li>
-              <li><a href="https://www.gv.com/sprint/">Google "Design Sprint"</a></li>
+              <li><a href="https://www.gv.com/sprint/" target="_blank">Google "Design Sprint"</a></li>
             </ul>
             <p>Van onze hand:</p>
             <ul>
-              <li><a href="https://infi.nl/nieuws/kickstart-je-project-met-een-walking-skeleton/">Blogpost: Walking Skeletons</a></li>
-              <li><a href="https://infi.nl/onze-klanten/">Site: Onze klanten</a> (en hun gebruikers, dus!)</li>
+              <li><a href="https://infi.nl/nieuws/kickstart-je-project-met-een-walking-skeleton/" target="_blank">Blogpost: Walking Skeletons</a></li>
+              <li><a href="https://infi.nl/onze-klanten/" target="_blank">Site: Onze klanten</a> (en hun gebruikers, dus!)</li>
             </ul>
           </section>
         </div>
@@ -291,15 +291,15 @@
             <ul>
               <li>Git (flow op project afgestemd)</li>
               <li>Unit tests, integration tests, end-to-end tests</li>
-              <li><a href="javascript:;">Sonarqube</a>, <a href="javascript:;">ESLint</a>, etc.</li>
-              <li><a href="javascript:;">SOLID</a> (of <a href="javascript:;">DAMP</a>), <a href="javascript:;">YAGNI</a>, <a href="javascript:;">KISS</a></li>
-              <li><a href="javascript:;">Domain-Driven Design</a></li>
+              <li><a href="https://www.sonarqube.org/" target="_blank">Sonarqube</a>, <a href="https://eslint.org/" target="_blank">ESLint</a>, etc.</li>
+              <li><a href="https://en.wikipedia.org/wiki/SOLID" target="_blank">SOLID</a> (of <a href="https://stackoverflow.com/q/6453235" target="_blank">DAMP</a>), <a href="https://martinfowler.com/bliki/Yagni.html" target="_blank">YAGNI</a>, <a href="https://en.wikipedia.org/wiki/KISS_principle" target="_blank">KISS</a></li>
+              <li><a href="https://www.goodreads.com/en/book/show/179133.Domain_Driven_Design" target="_blank">Domain-Driven Design</a></li>
             </ul>
             <p>Van onze hand:</p>
             <ul>
-              <li><a href="https://infi.nl/nieuws/end-to-end-testen-met-puppeteer/">Blogpost: E2E Testen met Puppeteer</a></li>
-              <li><a href="https://infi.nl/nieuws/mob-programming-pilot/">Blogpost: Mob Programming</a></li>
-              <li><a href="https://infi.nl/nieuws/setup-cypress-and-auth0-for-spas/">Blogpost: Auth0 en Cypress</a></li>
+              <li><a href="https://infi.nl/nieuws/end-to-end-testen-met-puppeteer/" target="_blank">Blogpost: E2E Testen met Puppeteer</a></li>
+              <li><a href="https://infi.nl/nieuws/mob-programming-pilot/" target="_blank">Blogpost: Mob Programming</a></li>
+              <li><a href="https://infi.nl/nieuws/setup-cypress-and-auth0-for-spas/" target="_blank">Blogpost: Auth0 en Cypress</a></li>
             </ul>
           </section>
         </div>
@@ -330,15 +330,15 @@
             </ul>
             <p>Denk aan <em>bijvoorbeeld</em>:</p>
             <ul>
-              <li><a href="javascript:;">Architecural Decision Records</a>, <a href="javascript:;">C4 Model</a></li>
-              <li><a href="javascript:;">Ansible</a>, <a href="javascript:;">Docker</a>, <a href="javascript:;">Terraform</a></li>
-              <li><a href="javascript:;">GitLab</a> (SAAS of self-hosted), <a href="javascript:;">GitHub</a></li>
-              <li><a href="javascript:;">GitLab CI</a>, <a href="javascript:;">GitHub Actions</a>, <a href="javascript:;">Azure Devops</a>, <a href="javascript:;">CircleCI</a>, <a href="javascript:;">Octopus</a></li>
+              <li><a href="https://adr.github.io/" target="_blank">Architecural Decision Records</a>, <a href="https://c4model.com/" target="_blank">C4 Model</a></li>
+              <li><a href="https://www.ansible.com/" target="_blank">Ansible</a>, <a href="https://www.docker.com/" target="_blank">Docker</a>, <a href="https://www.terraform.io/" target="_blank">Terraform</a></li>
+              <li><a href="https://gitlab.com/" target="_blank">GitLab</a> (SAAS of self-hosted), <a href="https://github.com/" target="_blank">GitHub</a></li>
+              <li><a href="https://docs.gitlab.com/ee/ci/" target="_blank">GitLab CI</a>, <a href="https://github.com/features/actions" target="_blank">GitHub Actions</a>, <a href="https://azure.microsoft.com/en-us/services/devops/" target="_blank">Azure Devops</a>, <a href="https://circleci.com/" target="_blank">CircleCI</a>, <a href="https://octopus.com/" target="_blank">Octopus</a></li>
             </ul>
             <p>Van onze hand:</p>
             <ul>
-              <li><a href="https://infi.nl/nieuws/monitoring-elasticsearch-using-zabbix-and-elasticsearch-part-1/">Blogpost: Elasticsearch + Zabbix part 1</a> en <a href="https://infi.nl/nieuws/monitoring-elasticsearch-using-zabbix-and-elasticsearch-part-2/">part 2</a></li>
-              <li><a href="https://www.youtube.com/watch?v=kFDGxk3Exr8">Talk: GitLab CI/CD</a></li>
+              <li><a href="https://infi.nl/nieuws/monitoring-elasticsearch-using-zabbix-and-elasticsearch-part-1/" target="_blank">Blogpost: Elasticsearch + Zabbix part 1</a> en <a href="https://infi.nl/nieuws/monitoring-elasticsearch-using-zabbix-and-elasticsearch-part-2/" target="_blank">part 2</a></li>
+              <li><a href="https://www.youtube.com/watch?v=kFDGxk3Exr8" target="_blank">Talk: GitLab CI/CD</a></li>
             </ul>
           </section>
         </div>
@@ -367,20 +367,20 @@
             </ul>
             <p>Denk aan <em>bijvoorbeeld</em>:</p>
             <ul>
-              <li><a href="javascript:;">Azure</a> (vanuit ons Microsoft partnership), <a href="javascript:;">AWS</a>, <a href="javascript:;">Google Cloud</a></li>
-              <li><a href="javascript:;">.NET Core</a>, <a href="javascript:;">PHP (met modern framework)</a>, of <a href="javascript:;">Node (met TypeScript)</a></li>
-              <li><a href="javascript:;">Vue</a>, <a href="javascript:;">Angular</a>, <a href="javascript:;">React</a></li>
-              <li><a href="javascript:;">TailwindCSS</a>, <a href="javascript:;">Bootstrap</a></li>
-              <li><a href="javascript:;">ReactNative</a></li>
-              <li><a href="javascript:;">SQL</a>, <a href="javascript:;">Document-storage</a>, Service Buses, etc.</li>
+              <li><a href="https://azure.microsoft.com/" target="_blank">Azure</a> (vanuit ons Microsoft partnership), <a href="https://aws.amazon.com/" target="_blank">AWS</a>, <a href="https://cloud.google.com/" target="_blank">Google Cloud</a></li>
+              <li><a href="https://dotnet.microsoft.com/" target="_blank">.NET Core</a>, <a href="https://www.php.net/" target="_blank">PHP (met modern framework)</a>, of <a href="https://nodejs.org/" target="_blank">Node (met TypeScript)</a></li>
+              <li><a href="https://vuejs.org/" target="_blank">Vue</a>, <a href="https://angular.io/" target="_blank">Angular</a>, <a href="https://reactjs.org/" target="_blank">React</a></li>
+              <li><a href="https://tailwindcss.com/" target="_blank">TailwindCSS</a>, <a href="https://getbootstrap.com/" target="_blank">Bootstrap</a></li>
+              <li><a href="https://reactnative.dev/" target="_blank">ReactNative</a></li>
+              <li><a href="https://en.wikipedia.org/wiki/SQL" target="_blank">SQL</a>, <a href="https://en.wikipedia.org/wiki/Document-oriented_database" target="_blank">Document-storage</a>, Service Buses, etc.</li>
             </ul>
             <p>Van onze hand:</p>
             <ul>
-              <li><a href="https://infi.nl/nieuws/c-voor-een-java-programmeur/">Blogpost: C# voor een Java programmeur</a></li>
-              <li><a href="https://infi.nl/nieuws/development-in-react-using-typescript-and-webpack/">Blogpost: React met TypeScript en WebPack</a></li>
-              <li><a href="https://www.youtube.com/watch?v=KAuXDjtswpM">Talk: VueJS Deep Dive</a></li>
-              <li><a href="https://infi.nl/nieuws/mobiele-frameworks/">Blogpost: Mobiele Frameworks</a></li>
-              <li><a href="https://www.youtube.com/watch?v=L4xVpPOye9I">Webinar: Mobiele Apps</a></li>
+              <li><a href="https://infi.nl/nieuws/c-voor-een-java-programmeur/" target="_blank">Blogpost: C# voor een Java programmeur</a></li>
+              <li><a href="https://infi.nl/nieuws/development-in-react-using-typescript-and-webpack/" target="_blank">Blogpost: React met TypeScript en WebPack</a></li>
+              <li><a href="https://www.youtube.com/watch?v=KAuXDjtswpM" target="_blank">Talk: VueJS Deep Dive</a></li>
+              <li><a href="https://infi.nl/nieuws/mobiele-frameworks/" target="_blank">Blogpost: Mobiele Frameworks</a></li>
+              <li><a href="https://www.youtube.com/watch?v=L4xVpPOye9I" target="_blank">Webinar: Mobiele Apps</a></li>
             </ul>
           </section>
         </div>
@@ -413,17 +413,17 @@
             </ul>
             <p>Denk aan <em>bijvoorbeeld</em>:</p>
             <ul>
-              <li><a href="javascript:;">Scrum</a> of <a href="javascript:;">Kanban</a></li>
+              <li><a href="https://scrumguides.org/" target="_blank">Scrum</a> of <a href="https://en.wikipedia.org/wiki/Kanban_(development)" target="_blank">Kanban</a></li>
               <li>Retrospectives, Lean</li>
-              <li><a href="javascript:;">Trello</a>, <a href="javascript:;">Jira</a>, <a href="javascript:;">Clubhouse.io</a>, <a href="javascript:;">YouTrack</a></li>
+              <li><a href="https://trello.com/" target="_blank">Trello</a>, <a href="https://www.atlassian.com/software/jira" target="_blank">Jira</a>, <a href="https://shortcut.com/" target="_blank">Shortcut (formerly Clubhouse)</a>, <a href="https://www.jetbrains.com/youtrack/" target="_blank">YouTrack</a></li>
               </ul>
             <p>Van onze hand:</p>
             <ul>
-              <li><a href="https://infi.nl/nieuws/effectief-aan-de-slag-met-retro-uitkomsten/">Blogpost: Retro Uitkomsten</a></li>
-              <li><a href="https://infi.nl/nieuws/5-tips-voor-de-perfecte-user-story/">Blogpost: Perfecte user stories</a></li>
-              <li><a href="https://infi.nl/nieuws/vijf-tips-voor-remote-demos/">Blogpost: Tips voor remote demos</a></li>
-              <li><a href="https://infi.nl/nieuws/liever-kanban-dan-scrum/">Blogpost: Kanban vs Scrum</a></li>
-              <li><a href="https://infi.nl/nieuws/teamsamenstelling/">Blogpost: teamsamenstelling</a></li>
+              <li><a href="https://infi.nl/nieuws/effectief-aan-de-slag-met-retro-uitkomsten/" target="_blank">Blogpost: Retro Uitkomsten</a></li>
+              <li><a href="https://infi.nl/nieuws/5-tips-voor-de-perfecte-user-story/" target="_blank">Blogpost: Perfecte user stories</a></li>
+              <li><a href="https://infi.nl/nieuws/vijf-tips-voor-remote-demos/" target="_blank">Blogpost: Tips voor remote demos</a></li>
+              <li><a href="https://infi.nl/nieuws/liever-kanban-dan-scrum/" target="_blank">Blogpost: Kanban vs Scrum</a></li>
+              <li><a href="https://infi.nl/nieuws/teamsamenstelling/" target="_blank">Blogpost: teamsamenstelling</a></li>
             </ul>
           </section>
         </div>
@@ -455,15 +455,15 @@
               <li>Presentaties (intern en extern)</li>
               <li>Leergangen, zelfstudie</li>
               <li>Congressen en meetups bezoeken</li>
-              <li><a href="javascript:;">Kibana</a>, <a href="javascript:;">Sentry</a>, <a href="javascript:;">Zabbix</a>, etc.</li>
+              <li><a href="https://www.elastic.co/kibana/" target="_blank">Kibana</a>, <a href="https://sentry.io/" target="_blank">Sentry</a>, <a href="https://www.zabbix.com/" target="_blank">Zabbix</a>, etc.</li>
             </ul>
             <p>Van onze hand:</p>
             <ul>
-              <li><a href="https://infi.nl/nieuws/infi-con-2020-wrap-up/">INFI-CON 2020</a> en <a href="https://infi.nl/nieuws/infi-con-2019-wrap-up/">INFI-CON 2019</a></li>
-              <li><a href="https://infi.nl/nieuws/spreken-met-impact/">Blogpost: Spreken met Impact</a></li>
-              <li><a href="https://infi.nl/nieuws/je-eigen-linux-kernel-bouwen/">Blogpost: Je eigen Linux kernel bouwen</a></li>
-              <li><a href="https://infi.nl/nieuws/software-engineering-bestaat-niet/">Blogpost: "Software engineering" bestaat niet</a></li>
-              <li><a href="https://infi.nl/nieuws/vakmanschap-is-meesterschap/">Blogpost: Vakmanschap is meesterschap</a></li>
+              <li><a href="https://infi.nl/nieuws/infi-con-2020-wrap-up/" target="_blank">INFI-CON 2020</a> en <a href="https://infi.nl/nieuws/infi-con-2019-wrap-up/" target="_blank">INFI-CON 2019</a></li>
+              <li><a href="https://infi.nl/nieuws/spreken-met-impact/" target="_blank">Blogpost: Spreken met Impact</a></li>
+              <li><a href="https://infi.nl/nieuws/je-eigen-linux-kernel-bouwen/" target="_blank">Blogpost: Je eigen Linux kernel bouwen</a></li>
+              <li><a href="https://infi.nl/nieuws/software-engineering-bestaat-niet/" target="_blank">Blogpost: "Software engineering" bestaat niet</a></li>
+              <li><a href="https://infi.nl/nieuws/vakmanschap-is-meesterschap/" target="_blank">Blogpost: Vakmanschap is meesterschap</a></li>
             </ul>
           </section>
         </div>
@@ -492,21 +492,21 @@
               <li>OS naar keuze (Windows, OSX, Linux) voor devs</li>
               <li>Open Source gebruiken en ondersteunen</li>
               <li>Meetups hosten en/of organiseren</li>
-              <li>Onszelf zijn: "<em><a href="https://infi.nl/manifest/">Wij zijn mensen.</a></em>"</li>
+              <li>Onszelf zijn: "<em><a href="https://infi.nl/manifest/" target="_blank">Wij zijn mensen.</a></em>"</li>
             </ul>
             <p>Denk aan <em>bijvoorbeeld</em>:</p>
             <ul>
               <li>OWASP</li>
               <li>Password managers, 2FA, GPG, SSH</li>
-              <li><a href="javascript:;">Locust</a>, <a href="javascript:;">OctoPerf</a>, <a href="javascript:;">JMeter</li>
-              <li><a href="javascript:;">Auth0</a>, <a href="javascript:;">Stripe</a>, <a href="javascript:;">SendGrid</a>, <a href="javascript:;">Contentful</a>, <a href="javascript:;">Lokalise</a>, etc.</li>
+              <li><a href="https://locust.io/" target="_blank">Locust</a>, <a href="https://octoperf.com/" target="_blank">OctoPerf</a>, <a href="https://jmeter.apache.org/" target="_blank">JMeter</li>
+              <li><a href="https://auth0.com/" target="_blank">Auth0</a>, <a href="https://stripe.com/" target="_blank">Stripe</a>, <a href="https://sendgrid.com/" target="_blank">SendGrid</a>, <a href="https://www.contentful.com/" target="_blank">Contentful</a>, <a href="https://lokalise.com/" target="_blank">Lokalise</a>, etc.</li>
               <li>Onbeheerde laptops altijd locken <!-- en mocht je dat een keer vergeten, kun je er op rekenen dat je collega's hier op ludieke wijze (met serieuze ondertoon!) op zullen attenderen... --></li>
             </ul>
             <p>Van onze hand:</p>
             <ul>
-              <li><a href="https://infi.nl/manifest/">Het Infi Manifest</a></li>
-              <li><a href="https://infi.nl/nieuws/spa-necromancy/">Blogpost: SPA Necromancy</a></li>
-              <li><a href="https://infi.nl/nieuws/launching-free-open-source-software/">Blogpost: FOSS lanceren</a></li>
+              <li><a href="https://infi.nl/manifest/" target="_blank">Het Infi Manifest</a></li>
+              <li><a href="https://infi.nl/nieuws/spa-necromancy/" target="_blank">Blogpost: SPA Necromancy</a></li>
+              <li><a href="https://infi.nl/nieuws/launching-free-open-source-software/" target="_blank">Blogpost: FOSS lanceren</a></li>
             </ul>
           </section>
         </div>
@@ -514,7 +514,7 @@
     </div>
 
     <footer>
-      © 2021, Infi | <a href="https://infi.nl">infi.nl</a> | <a href="https://werkenbij.infi.nl">werkenbij.infi.nl</a> | Vragen? <a href="mailto:jeroen@infi.nl">jeroen@infi.nl</a>
+      © 2021, Infi | <a href="https://infi.nl" target="_blank">infi.nl</a> | <a href="https://werkenbij.infi.nl" target="_blank">werkenbij.infi.nl</a> | Vragen? <a href="mailto:jeroen@infi.nl">jeroen@infi.nl</a>
     </footer>
   </body>
 </html>


### PR DESCRIPTION
Assorti tweaks en fixes om richting een v1.0.0 release te komen. Tip voor de reviewer: in plaats van of in aanvulling op de diff reviewen kan het simpelweg lokaal openen van de html file en handmatig "testen" ook een goede manier zijn om te kijken of de PR correct is.

Fixes #2 - links naar voorbeelden
Fixes #8 - gebroken links verwijderen
Fixes #11 - TravisCI weghalen
Fixes #12 - sterker laatste blok
See also #10 - Security prominentere plek geven