### PR TITLE
Collapse/expand voor de details in blokken

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -78,6 +78,7 @@
       }
 
       header {
+        z-index: 1;
         padding: 2rem;
         position: sticky;
         top: 0;
@@ -88,6 +89,18 @@
       footer {
         font-size: 0.8rem;
         border-top: 1px solid rgba(0, 0, 0, 0.1);
+      }
+
+      .sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap; /* added line */
+        border: 0;
       }
 
       .wrapper {
@@ -123,6 +136,7 @@
       }
 
       .block {
+        position: relative;
         text-shadow: 2px 2px 3px rgba(50, 50, 50, 0.5);
         box-shadow: inset 5px 5px 20px rgba(0, 0, 0, 0.2);
         display: flex;
@@ -160,18 +174,31 @@
       }
 
       .details-toggle {
-        margin: 10px 0;
+        position: absolute;
+        top: 20px;
+        right: 20px;
+        width: 2em;
+        height: 2em;
+        opacity: 0.5;
         background: none !important;
         border: none;
-        padding: 0!important;
-        color: inherit;
+        padding: 0 !important;
         font-size: inherit;
         font-family: inherit;
-        text-decoration: underline;
         cursor: pointer;
+        color: rgba(0, 0, 0, 0.5);
+        border: 2px solid rgba(0, 0, 0, 0.1);
+        border-radius: 50%;
+        text-align: center;
       }
       .details-toggle:hover {
-        text-decoration-style: double;
+        opacity: 1;
+      }
+      .details-toggle:before {
+        content: '▲';
+      }
+      .view-overview .details-toggle:before {
+        content: '▼'
       }
 
       .details {
@@ -206,6 +233,12 @@
 
       @media (max-width: 1024px) {
         header, .headline, .details { padding: 1rem; }
+        .details-toggle {
+          top: 10px;
+          right: 10px;
+          width: 1.5em;
+          height: 1.5em;
+        }
       }
       @media (max-width: 720px) {
         .infi-test { padding: 0.5rem 1rem; }
@@ -235,7 +268,7 @@
       <h1><a href="javascript: history.replaceState(null, null, ' '); window.scrollTo(0, 0)">The Infi Way</a></h1>
       <p>Bij Infi werken we graag op de volgende manier.</p>
     </header>
-    <div class="wrapper view-overview" id="viewToggle">
+    <div class="wrapper" id="viewToggle">
       <section class="intro">
         <div class="infi-test">
           <span id="infi-test" class="block-anchor-with-offset"></span>
@@ -276,7 +309,7 @@
               <span class="anchor-hint">#</span>
             </a></h2>
             <p>Wij werken voor <em>de klant van onze klant</em>. Ze gebruiken software om <em>hun</em> doelen te bereiken, ons doel is hen daarbij te helpen.</p>
-            <p><button class="details-toggle" onclick="document.getElementById('viewToggle').classList.toggle('view-overview'); location.hash='gebruikers';">Toggle details...</button></p>
+            <button class="details-toggle" onclick="document.getElementById('viewToggle').classList.toggle('view-overview'); location.hash='gebruikers';"><span class="sr-only">Details in-/uitklappen...</span></button>
             <p class="block-image">
               <svg xmlns="http://www.w3.org/2000/svg" height="164px" viewBox="0 0 24 24" width="164px" fill="rgba(255, 255, 255, 0.5)"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M9 13.75c-2.34 0-7 1.17-7 3.5V19h14v-1.75c0-2.33-4.66-3.5-7-3.5zM4.34 17c.84-.58 2.87-1.25 4.66-1.25s3.82.67 4.66 1.25H4.34zM9 12c1.93 0 3.5-1.57 3.5-3.5S10.93 5 9 5 5.5 6.57 5.5 8.5 7.07 12 9 12zm0-5c.83 0 1.5.67 1.5 1.5S9.83 10 9 10s-1.5-.67-1.5-1.5S8.17 7 9 7zm7.04 6.81c1.16.84 1.96 1.96 1.96 3.44V19h4v-1.75c0-2.02-3.5-3.17-5.96-3.44zM15 12c1.93 0 3.5-1.57 3.5-3.5S16.93 5 15 5c-.54 0-1.04.13-1.5.35.63.89 1 1.98 1 3.15s-.37 2.26-1 3.15c.46.22.96.35 1.5.35z"/></svg>
             </p>
@@ -312,7 +345,7 @@
               <span class="anchor-hint">#</span>
             </a></h2>
             <p>We werken op een moderne manier, gericht op kwaliteit. <em>Goed</em> is op de lange termijn <em>ook</em> het goedkoopst.</p>
-            <p><button class="details-toggle" onclick="document.getElementById('viewToggle').classList.toggle('view-overview'); location.hash='principes';">Toggle details...</button></p>
+            <button class="details-toggle" onclick="document.getElementById('viewToggle').classList.toggle('view-overview'); location.hash='principes';"><span class="sr-only">Details in-/uitklappen...</span></button>
             <p class="block-image">
               <svg xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" height="164px" viewBox="0 0 24 24" width="164px" fill="rgba(255, 255, 255, 0.5)"><g><rect fill="none" height="24" width="24"/></g><g><g><path d="M23,11.99l-2.44-2.79l0.34-3.69l-3.61-0.82L15.4,1.5L12,2.96L8.6,1.5L6.71,4.69L3.1,5.5L3.44,9.2L1,11.99l2.44,2.79 l-0.34,3.7l3.61,0.82L8.6,22.5l3.4-1.47l3.4,1.46l1.89-3.19l3.61-0.82l-0.34-3.69L23,11.99z M19.05,13.47l-0.56,0.65l0.08,0.85 l0.18,1.95l-1.9,0.43l-0.84,0.19l-0.44,0.74l-0.99,1.68l-1.78-0.77L12,18.85l-0.79,0.34l-1.78,0.77l-0.99-1.67l-0.44-0.74 l-0.84-0.19l-1.9-0.43l0.18-1.96l0.08-0.85l-0.56-0.65l-1.29-1.47l1.29-1.48l0.56-0.65L5.43,9.01L5.25,7.07l1.9-0.43l0.84-0.19 l0.44-0.74l0.99-1.68l1.78,0.77L12,5.14l0.79-0.34l1.78-0.77l0.99,1.68l0.44,0.74l0.84,0.19l1.9,0.43l-0.18,1.95l-0.08,0.85 l0.56,0.65l1.29,1.47L19.05,13.47z"/><polygon points="10.09,13.75 7.77,11.42 6.29,12.91 10.09,16.72 17.43,9.36 15.95,7.87"/></g></g></svg>
             </p>
@@ -353,7 +386,7 @@
               <span class="anchor-hint">#</span>
             </a></h2>
             <p>Broncode is dat: de <em>bron</em>. Zelfbeschrijvend en dus bruikbaar voor <em>elke</em> ontwikkelaar, van Infi of anderszins.</p>
-            <p><button class="details-toggle" onclick="document.getElementById('viewToggle').classList.toggle('view-overview'); location.hash='broncode';">Toggle details...</button></p>
+            <button class="details-toggle" onclick="document.getElementById('viewToggle').classList.toggle('view-overview'); location.hash='broncode';"><span class="sr-only">Details in-/uitklappen...</span></button>
             <p class="block-image">
               <svg xmlns="http://www.w3.org/2000/svg" height="164px" viewBox="0 0 24 24" width="164px" fill="rgba(255, 255, 255, 0.5)"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"/></svg>
             </p>
@@ -393,7 +426,7 @@
               <span class="anchor-hint">#</span>
             </a></h2>
             <p>We gebruiken bij voorkeur altijd de "<em>best tool for the job</em>"; we zijn generalisten die zo nodig snel kunnen specialiseren en verdiepen.</p>
-            <p><button class="details-toggle" onclick="document.getElementById('viewToggle').classList.toggle('view-overview'); location.hash='technologie';">Toggle details...</button></p>
+            <button class="details-toggle" onclick="document.getElementById('viewToggle').classList.toggle('view-overview'); location.hash='technologie';"><span class="sr-only">Details in-/uitklappen...</span></button>
             <p class="block-image">
               <svg xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" height="164px" viewBox="0 0 24 24" width="164px" fill="rgba(255, 255, 255, 0.5)"><g><rect fill="none" height="24" width="24"/></g><g><g><path d="M6.36,18.78L6.61,21l1.62-1.54l2.77-7.6c-0.68-0.17-1.28-0.51-1.77-0.98L6.36,18.78z"/><path d="M14.77,10.88c-0.49,0.47-1.1,0.81-1.77,0.98l2.77,7.6L17.39,21l0.26-2.22L14.77,10.88z"/><path d="M15,8c0-1.3-0.84-2.4-2-2.82V3h-2v2.18C9.84,5.6,9,6.7,9,8c0,1.66,1.34,3,3,3S15,9.66,15,8z M12,9c-0.55,0-1-0.45-1-1 c0-0.55,0.45-1,1-1s1,0.45,1,1C13,8.55,12.55,9,12,9z"/></g></g></svg>
             </p>
@@ -436,7 +469,7 @@
               <span class="anchor-hint">#</span>
             </a></h2>
             <p>Teams werken <em>autonoom</em>, maar kiezen vrijwel altijd een vorm van <em>agile</em> werken. Met Product Owner van de klant.</p>
-            <p><button class="details-toggle" onclick="document.getElementById('viewToggle').classList.toggle('view-overview'); location.hash='proces-en-team';">Toggle details...</button></p>
+            <button class="details-toggle" onclick="document.getElementById('viewToggle').classList.toggle('view-overview'); location.hash='proces-en-team';"><span class="sr-only">Details in-/uitklappen...</span></button>
             <p class="block-image">
               <svg xmlns="http://www.w3.org/2000/svg" height="164px" viewBox="0 0 24 24" width="164px" fill="rgba(255, 255, 255, 0.5)"><path d="M0 0h24v24H0V0zm0 0h24v24H0V0z" fill="none"/><path d="M22 9V7h-2V5c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-2h2v-2h-2v-2h2v-2h-2V9h2zm-4 10H4V5h14v14zM6 13h5v4H6v-4zm6-6h4v3h-4V7zM6 7h5v5H6V7zm6 4h4v6h-4v-6z"/></svg>
             </p>
@@ -480,7 +513,7 @@
               <span class="anchor-hint">#</span>
             </a></h2>
             <p>Maatwerksoftware bouwen is een ambacht. We willen vol vertrouwen (én trots!) een kijkje achter de schermen kunnen geven.</p>
-            <p><button class="details-toggle" onclick="document.getElementById('viewToggle').classList.toggle('view-overview'); location.hash='ambacht';">Toggle details...</button></p>
+            <button class="details-toggle" onclick="document.getElementById('viewToggle').classList.toggle('view-overview'); location.hash='ambacht';"><span class="sr-only">Details in-/uitklappen...</span></button>
             <p class="block-image">
               <svg xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" height="164px" viewBox="0 0 24 24" width="164px" fill="rgba(255, 255, 255, 0.5)"><g><path d="M0,0h24v24H0V0z" fill="none"/><path d="M0,0h24v24H0V0z" fill="none"/></g><g><path d="M12,17.27L18.18,21l-1.64-7.03L22,9.24l-7.19-0.61L12,2L9.19,8.63L2,9.24l5.46,4.73L5.82,21L12,17.27z"/></g></svg>
             </p>
@@ -521,7 +554,7 @@
               <span class="anchor-hint">#</span>
             </a></h2>
             <p>Sommige dingen spreken voor ons voor zichzelf: dit hoort er <em>altijd</em> bij. Denk aan Security, Performance, Backups, kritisch meedenken, en jezelf kunnen zijn.</p>
-            <p><button class="details-toggle" onclick="document.getElementById('viewToggle').classList.toggle('view-overview'); location.hash='overigen';">Toggle details...</button></p>
+            <button class="details-toggle" onclick="document.getElementById('viewToggle').classList.toggle('view-overview'); location.hash='overigen';"><span class="sr-only">Details in-/uitklappen...</span></button>
             <p class="block-image">
               <svg xmlns="http://www.w3.org/2000/svg" height="164px" viewBox="0 0 24 24" width="164px" fill="rgba(255, 255, 255, 0.5)"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M7 18c-2.21 0-4-1.79-4-4s1.79-4 4-4 4 1.79 4 4-1.79 4-4 4zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm4-2c-2.21 0-4-1.79-4-4s1.79-4 4-4 4 1.79 4 4-1.79 4-4 4zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm5.6 17.6c-2.21 0-4-1.79-4-4s1.79-4 4-4 4 1.79 4 4-1.79 4-4 4zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"/></svg>
             </p>


### PR DESCRIPTION
Dit is een voorstel om een stapje op #13 te zetten: het in-/uitklappen van details in blokken. Ik ben nog buiten GitHub om bij collega's aan het crowdsourcen wat een goede default way to go is.