### PR TITLE
Vervang "lakmoesproef"

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -277,7 +277,7 @@
             <span class="anchor-hint">#</span>
           </a></h2>
           <p>
-            Een vlugge <a href="https://nl.wikipedia.org/wiki/Lakmoes" target="_blank">lakmoesproef</a> of je ruwweg <em>The Infi Way</em> volgt.
+            Vlotte steekproef om te checken of je ruwweg <em>The Infi Way</em> volgt.
             Een soort <a href="https://www.joelonsoftware.com/2000/08/09/the-joel-test-12-steps-to-better-code/" target="_blank">Joel Test</a>.
           </p>
           <ol>


### PR DESCRIPTION
Een lakmoesproef is niet "ruwweg" maar geeft juist uitslag. Dus versimpelen we de boel zodat het beter klopt.

Fixes #21