### PR TITLE
Fix link style in Safari

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -72,7 +72,8 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 a {
-    text-decoration: underline 1px solid var(--color-orange);
+    text-decoration-thickness: 1px;
+    text-decoration-color: var(--color-orange);
 }
 
 a, a:link, a:visited, a:focus, a:active {


### PR DESCRIPTION
Safari heeft alleen gedeeltelijke, en dan nog geprefixte support voor de `text-decoration` shorthand ([MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)). Ik heb de properties losgetrokken. `underline`/`solid` lijken de defaults in de browsers die ik heb getest (Safari, Firefox, Chrome) dus die heb ik weggelaten.