### PR TITLE
Replace 'Infi' with something more generic in topic texts

### DIFF
--- a/content/en.json
+++ b/content/en.json
@@ -116,7 +116,7 @@
     },
     "source-code": {
       "title": "Code is the Source",
-      "subtitle": "Source code is just that: the <em>source</em>. Self-documenting, so usable for <em>any</em> developer, from Infi or otherwise.",
+      "subtitle": "Source code is just that: the <em>source</em>. Self-documenting, so usable for <em>any</em> developer, our own or otherwise.",
       "how-title": "How we like to do this:",
       "how": [
         "Architecture <em>in</em> the source",
@@ -184,7 +184,7 @@
         "<em>All</em> team members help with refinement",
         "Minimum of 2 people per <em>team</em>, split up from 6-7 upward",
         "Call in help from colleagues in other teams",
-        "Infi and client regularly work from the same location",
+        "Regularly work together with the client at the same location",
         "Testers, designers, and other experts called in when needed"
       ],
       "examples-title": "Concrete examples:",

--- a/content/nl.json
+++ b/content/nl.json
@@ -116,7 +116,7 @@
     },
     "source-code": {
       "title": "Code is de Bron",
-      "subtitle": "Broncode is dat: de <em>bron</em>. Zelfbeschrijvend en dus bruikbaar voor <em>elke</em> ontwikkelaar, van Infi of anderszins.",
+      "subtitle": "Broncode is dat: de <em>bron</em>. Zelfbeschrijvend en dus bruikbaar voor <em>elke</em> ontwikkelaar, van onszelf of anderszins.",
       "how-title": "Hoe we dat graag doen:",
       "how": [
         "Architectuur <em>in</em> de bron",
@@ -184,7 +184,7 @@
         "<em>Alle</em> teamleden helpen refinen",
         "Minimaal 2 personen per <em>team</em>, splitsen vanaf 6 a 7",
         "Collega's uit andere teams invliegen",
-        "Infi en klant regelmatig samen in één kantoor",
+        "Regelmatig samenwerken met klant in één kantoor",
         "Testers, designers, en overige expertise aanhaken"
       ],
       "examples-title": "Denk aan bijvoorbeeld:",


### PR DESCRIPTION
The word 'Infi' has been replaced with something more generic in the topic texts. Fixes issue https://github.com/infi-nl/the-infi-way/issues/40
