### PR TITLE
default to Dutch, since this is our primary audience

### DIFF
--- a/build.js
+++ b/build.js
@@ -4,7 +4,7 @@ const fs = require('fs/promises');
 const templateFile = `${__dirname}/template.html`;
 const contentDir = `${__dirname}/content`;
 const outputDir = `${__dirname}/build`;
-const langMappings = { en: 'index' };
+const langMappings = { nl: 'index' };
 
 const cliHelpText = `
 Usage: ./build.js [options]

--- a/template.html
+++ b/template.html
@@ -353,10 +353,10 @@
     </div>
 
     <footer>
-      <a href="index.html">English</a>
-      | <a href="nl.html">Nederlands</a>
+      <a href="en.html">English</a>
+      | <a href="index.html">Nederlands</a>
       <p>---</p>
-      © 2022, Infi
+      © 2023, Infi
       | <a href="https://github.com/infi-nl/the-infi-way" target="_blank">Source</a>
       | <a href="https://infi.nl" target="_blank">infi.nl</a>
       | <a href="https://werkenbij.infi.nl" target="_blank">werkenbij.infi.nl</a>


### PR DESCRIPTION
In mijn ervaring verliezen gesprekken altijd wel wat nuance en diepte wanneer ze in een vreemde taal worden gevoerd. Bij Infi kiezen we er ook bewust voor om de Nederlandse voertaal aan te houden. Daarnaast bestaat ons primaire publiek uit (potentiële) klanten plus (potentiële) collega's. Waarom dan niet de Nederlandse taal gebruiken op way.infi.nl? Ik merkte in onze infi-way-workshop ook dat je toch een aantal keer de termen gaat vertalen om goed te begrijpen waar het over gaat. Een term zoals "Craft" heeft in mijn hoofd niet meteen hetzelfde effect als het woord "Ambacht".