### PR TITLE
Improve print styles

### DIFF
--- a/build/style.css
+++ b/build/style.css
@@ -23,6 +23,10 @@
     box-sizing: border-box;
 }
 
+@page {
+    margin: 0 1.3cm;
+}
+
 html, body {
     margin: 0;
     padding: 0;
@@ -431,43 +435,43 @@ h2:hover a .anchor-hint {
 .topic-icon {
     margin-right: .7rem;
     align-items: center;
+    border-radius: 8px;
+    border-width: 2px;
+    border-style: solid;
 }
 
-.svg-wrapper.users {
+.topic-icon.users {
     border-color: var(--color-topic-users);
 }
 
-.svg-wrapper.principles {
+.topic-icon.principles {
     border-color: var(--color-topic-principles);
 }
 
-.svg-wrapper.source-code {
+.topic-icon.source-code {
     border-color: var(--color-topic-source-code);
 }
 
-.svg-wrapper.technology {
+.topic-icon.technology {
     border-color: var(--color-topic-technology);
 }
 
-.svg-wrapper.process-and-team {
+.topic-icon.process-and-team {
     border-color: var(--color-topic-process-and-team);
 }
 
-.svg-wrapper.craft {
+.topic-icon.craft {
     border-color: var(--color-topic-craft);
 }
 
-.svg-wrapper.others {
+.topic-icon.others {
     border-color: var(--color-topic-others);
 }
 
-.svg-wrapper {
-    max-width: 2.7rem;
-    height: 2.7rem;
-    border-width: 2px;
-    border-style: solid;
+.topic-icon img {
+    max-width: 2.5rem;
+    height: 2.5rem;
     padding: .5rem;
-    border-radius: 8px;
 }
 
 @media print {
@@ -493,9 +497,7 @@ h2:hover a .anchor-hint {
     }
 
     .infi-test .topic-icon img {
-        print-color-adjust: exact;
-        -webkit-print-color-adjust: exact;
-        background-color: var(--color-block);
+        filter: invert(100%);
     }
 
     .details-toggle {
@@ -504,6 +506,7 @@ h2:hover a .anchor-hint {
 
     .block {
         page-break-before: always;
+        padding-top: 1.3cm;
     }
 
     .block-image {

--- a/build/style.css
+++ b/build/style.css
@@ -131,7 +131,6 @@ footer {
     margin-bottom: 1.7rem;
     display: flex;
     align-items: center;
-    
 }
 
 .infi-test ol li::before, .topic-icon {
@@ -462,4 +461,30 @@ h2:hover a .anchor-hint {
     border-style: solid;
     padding: .5rem;
     border-radius: 8px;
+}
+
+@media print {
+    :root {
+        --box-shadow: none;
+    }
+
+    .language-select {
+        display: none;
+    }
+
+    html, body {
+        text-shadow: none;
+    }
+
+    .details-toggle {
+        display: none;
+    }
+
+    .block {
+        page-break-before: always;
+    }
+
+    a {
+        text-decoration: none;
+    }
 }

--- a/build/style.css
+++ b/build/style.css
@@ -523,7 +523,7 @@ h2:hover a .anchor-hint {
     }
 
     header {
-        margin: 0 0 1rem;
+        margin-top: 0;
     }
 
     header h1 {
@@ -537,7 +537,6 @@ h2:hover a .anchor-hint {
 
     .infi-test h2 {
         font-size: 1.5rem;
-        margin-bottom: 0;
     }
 
     .infi-test p {
@@ -546,15 +545,23 @@ h2:hover a .anchor-hint {
 
     .infi-test ol li {
         page-break-inside: avoid;
-        margin-bottom: 0.5rem;
     }
 
-    .infi-test li::before {
+    .infi-test ol li::before {
         color: var(--color-text-light);
+        border-radius: 8px;
+    }
+
+    .infi-test .topic-icon {
+        border: none;
     }
 
     .infi-test .topic-icon img {
         filter: invert(100%);
+        height: 1.5rem;
+        padding-top: 0;
+        padding-bottom: 0;
+        padding-right: 0;
     }
 
     .block {

--- a/build/style.css
+++ b/build/style.css
@@ -513,7 +513,7 @@ h2:hover a .anchor-hint {
         --box-shadow: none;
     }
 
-    .language-select {
+    .utility-bar {
         display: none;
     }
 
@@ -555,10 +555,6 @@ h2:hover a .anchor-hint {
 
     .infi-test .topic-icon img {
         filter: invert(100%);
-    }
-
-    .details-toggle {
-        display: none;
     }
 
     .block {

--- a/build/style.css
+++ b/build/style.css
@@ -470,6 +470,10 @@ h2:hover a .anchor-hint {
     padding: .5rem;
 }
 
+.print-only {
+    display: none;
+}
+
 @page {
     margin: 7mm 13mm;
 }
@@ -537,5 +541,22 @@ h2:hover a .anchor-hint {
 
     a {
         text-decoration: none;
+    }
+
+    .no-print {
+        display: none;
+    }
+
+    .print-only {
+        display: initial;
+    }
+
+    footer {
+        text-align: left;
+    }
+
+    footer :last-child {
+        /* For some reason, without this, there a small "bite" out of the last line of text. */
+        padding-bottom: 1rem;
     }
 }

--- a/build/style.css
+++ b/build/style.css
@@ -146,6 +146,9 @@ footer {
     height: 1.7rem;
     counter-increment: infi-test;
     content: counter(infi-test);
+
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
 }
 
 .block {
@@ -193,6 +196,9 @@ h2:hover a .anchor-hint {
     align-items: center;
     justify-content: center;
     box-shadow: var(--box-shadow);
+
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
 }
 
 .block-image img {
@@ -475,6 +481,7 @@ h2:hover a .anchor-hint {
 
     html, body {
         text-shadow: none;
+        color: var(--color-black);
     }
 
     .infi-test li {
@@ -482,11 +489,12 @@ h2:hover a .anchor-hint {
     }
 
     .infi-test li::before {
-        print-color-adjust: exact;
+        color: var(--color-text-light);
     }
 
     .infi-test .topic-icon img {
         print-color-adjust: exact;
+        -webkit-print-color-adjust: exact;
         background-color: var(--color-block);
     }
 
@@ -499,7 +507,6 @@ h2:hover a .anchor-hint {
     }
 
     .block-image {
-        print-color-adjust: exact;
         margin-top: 0;
     }
 

--- a/build/style.css
+++ b/build/style.css
@@ -16,6 +16,7 @@
     --color-block: #212121;
 
     --box-shadow: 5px 5px 20px rgba(0, 0, 0, 0.2);
+    --block-image-height: 176px;
 }
 
 * {
@@ -184,10 +185,10 @@ h2:hover a .anchor-hint {
 }
 
 .block-image {
-    margin: 2rem 0 0 -88px;
+    margin: 2rem 0 0 calc(var(--block-image-height) / -2);
     border-radius: 50%;
-    flex: 0 0 176px;
-    height: 176px;
+    flex: 0 0 var(--block-image-height);
+    height: var(--block-image-height);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -337,8 +338,8 @@ h2:hover a .anchor-hint {
     }
 
     .block-image {
-        margin: -88px auto 0;
-        width: 176px;
+        margin: calc(var(--block-image-height) / -2) auto 0;
+        width: var(--block-image-height);
     }
 
     .block-content {
@@ -347,7 +348,7 @@ h2:hover a .anchor-hint {
     }
 
     .block-anchor-with-offset {
-        top: -88px;
+        top: calc(var(--block-image-height) / -2);
     }
 
     .details {
@@ -434,7 +435,7 @@ h2:hover a .anchor-hint {
     border-color: var(--color-topic-principles);
 }
 
-.svg-wrapper.source-code{
+.svg-wrapper.source-code {
     border-color: var(--color-topic-source-code);
 }
 
@@ -484,7 +485,16 @@ h2:hover a .anchor-hint {
         page-break-before: always;
     }
 
+    .block-image {
+        print-color-adjust: exact;
+        margin-top: 0;
+    }
+
     a {
         text-decoration: none;
+    }
+
+    footer {
+        page-break-before: always;
     }
 }

--- a/build/style.css
+++ b/build/style.css
@@ -23,10 +23,6 @@
     box-sizing: border-box;
 }
 
-@page {
-    margin: 0 1.3cm;
-}
-
 html, body {
     margin: 0;
     padding: 0;
@@ -474,6 +470,10 @@ h2:hover a .anchor-hint {
     padding: .5rem;
 }
 
+@page {
+    margin: 7mm 13mm;
+}
+
 @media print {
     :root {
         --box-shadow: none;
@@ -488,8 +488,31 @@ h2:hover a .anchor-hint {
         color: var(--color-black);
     }
 
-    .infi-test li {
+    header {
+        margin: 0 0 1rem;
+    }
+
+    header h1 {
+        margin-bottom: 0.5rem;
+    }
+
+    .infi-test {
+        padding: 0;
+        page-break-after: always;
+    }
+
+    .infi-test h2 {
+        font-size: 1.5rem;
+        margin-bottom: 0;
+    }
+
+    .infi-test p {
+        font-size: 0.9rem;
+    }
+
+    .infi-test ol li {
         page-break-inside: avoid;
+        margin-bottom: 0.5rem;
     }
 
     .infi-test li::before {
@@ -505,8 +528,7 @@ h2:hover a .anchor-hint {
     }
 
     .block {
-        page-break-before: always;
-        padding-top: 1.3cm;
+        page-break-after: always;
     }
 
     .block-image {
@@ -515,9 +537,5 @@ h2:hover a .anchor-hint {
 
     a {
         text-decoration: none;
-    }
-
-    footer {
-        page-break-before: always;
     }
 }

--- a/build/style.css
+++ b/build/style.css
@@ -129,14 +129,13 @@ footer {
 }
 
 .infi-test ol li {
-    margin-bottom: 1.7rem;
+    margin-bottom: 0.7rem;
     display: flex;
     align-items: center;
 }
 
 .infi-test ol li::before, .topic-icon {
     flex: 0 0 1.7rem;
-    height: 1.7rem;
     border-radius: 8px 0px 0px 8px;
     display: inline-flex;
     justify-content: center;
@@ -144,6 +143,7 @@ footer {
 }
 
 .infi-test ol li::before {
+    height: 1.7rem;
     counter-increment: infi-test;
     content: counter(infi-test);
 }
@@ -475,6 +475,10 @@ h2:hover a .anchor-hint {
 
     html, body {
         text-shadow: none;
+    }
+
+    .infi-test li {
+        page-break-inside: avoid;
     }
 
     .infi-test li::before {

--- a/build/style.css
+++ b/build/style.css
@@ -477,6 +477,15 @@ h2:hover a .anchor-hint {
         text-shadow: none;
     }
 
+    .infi-test li::before {
+        print-color-adjust: exact;
+    }
+
+    .infi-test .topic-icon img {
+        print-color-adjust: exact;
+        background-color: var(--color-block);
+    }
+
     .details-toggle {
         display: none;
     }

--- a/template.html
+++ b/template.html
@@ -48,8 +48,8 @@
           <ol>
             {{#each test.checks}}
             <li class="topic-{{topic}}">
-              <div class="topic-icon">
-                <img class="svg-wrapper {{topic}}" src="/resources/{{topic}}.svg" alt="icon of {{topic}}" type="image/svg+xml">
+              <div class="topic-icon {{topic}}">
+                <img src="/resources/{{topic}}.svg" alt="icon of {{topic}}" type="image/svg+xml">
               </div>
               <span>{{question}}</span>
             </li>

--- a/template.html
+++ b/template.html
@@ -62,7 +62,7 @@
         <div class="block topic-users">
           <span id="users" class="block-anchor-with-offset"></span>
           <div class="block-image">
-            <img height="132px" src="/resources/users.svg" alt="large icon of users"/>
+            <img src="/resources/users.svg" alt="large icon of users"/>
           </div>
           <div class="block-content">
             <section class="headline">
@@ -99,7 +99,7 @@
         <div class="block topic-principles">
           <span id="principles" class="block-anchor-with-offset"></span>
           <div class="block-image">
-            <img height="132px" src="/resources/principles.svg" alt="large icon of principles"/>
+            <img src="/resources/principles.svg" alt="large icon of principles"/>
           </div>
           <div class="block-content">
             <section class="headline">
@@ -136,7 +136,7 @@
         <div class="block topic-source-code">
           <span id="source-code" class="block-anchor-with-offset"></span>
           <div class="block-image">
-            <img height="132px" src="/resources/source-code.svg" alt="large icon of source code"/>
+            <img src="/resources/source-code.svg" alt="large icon of source code"/>
           </div>
           <div class="block-content">
             <section class="headline">
@@ -173,7 +173,7 @@
         <div class="block topic-technology">
           <span id="technology" class="block-anchor-with-offset"></span>
           <div class="block-image">
-            <img height="132px" src="/resources/technology.svg" alt="large icon of tecnology"/>
+            <img src="/resources/technology.svg" alt="large icon of tecnology"/>
           </div>
           <div class="block-content">
             <section class="headline">
@@ -210,7 +210,7 @@
         <div class="block topic-process-and-team">
           <span id="process-and-team" class="block-anchor-with-offset"></span>
           <div class="block-image">
-            <img height="132px" src="/resources/process-and-team.svg" alt="large icon of process and team"/>
+            <img src="/resources/process-and-team.svg" alt="large icon of process and team"/>
           </div>
           <div class="block-content">
             <section class="headline">
@@ -247,7 +247,7 @@
         <div class="block topic-craft">
           <span id="craft" class="block-anchor-with-offset"></span>
           <div class="block-image">
-            <img height="132px" src="/resources/craft.svg" alt="large icon of craft"/>
+            <img src="/resources/craft.svg" alt="large icon of craft"/>
           </div>
           <div class="block-content">
             <section class="headline">
@@ -284,7 +284,7 @@
         <div class="block topic-others">
           <span id="others" class="block-anchor-with-offset"></span>
           <div class="block-image">
-            <img height="132px" src="/resources/others.svg" alt="large icon of others"/>
+            <img src="/resources/others.svg" alt="large icon of others"/>
           </div>
           <div class="block-content">
             <section class="headline">

--- a/template.html
+++ b/template.html
@@ -321,7 +321,7 @@
       </section>
     </main>
 
-    <footer>
+    <footer class="no-print">
       © 2022, Infi
       | <a href="https://github.com/infi-nl/the-infi-way" target="_blank">Source</a>
       | <a href="https://infi.nl" target="_blank">infi.nl</a>
@@ -333,10 +333,19 @@
         by
         <a rel="cc:attributionURL dct:creator" property="cc:attributionName" href="https://github.com/infi-nl">Infi</a>
         is licensed under
-        <a href="http://creativecommons.org/licenses/by-nc-nd/4.0/" target="_blank" rel="license noopener noreferrer">
+        <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/" target="_blank" rel="license noopener noreferrer">
           CC BY-NC-ND 4.0
         </a>
       </p>
+    </footer>
+
+    <footer class="print-only">
+      <p>© 2022, Infi</p>
+      <p>Source: github.com/infi-nl/the-infi-way</p>
+      <p>infi.nl</p>
+      <p>werkenbij.infi.nl</p>
+      <p>{{footer.questions}} jeroen@infi.nl</p>
+      <p>The Infi Way by Infi is licensed under CC BY-NC-ND 4.0</p>
     </footer>
 
     <script>

--- a/template.html
+++ b/template.html
@@ -49,7 +49,8 @@
             {{#each test.checks}}
             <li class="topic-{{topic}}">
               <div class="topic-icon">
-                <img class="svg-wrapper {{topic}}" src="/resources/{{topic}}.svg" alt="icon of {{topic}}" type="image/svg+xml"></div>
+                <img class="svg-wrapper {{topic}}" src="/resources/{{topic}}.svg" alt="icon of {{topic}}" type="image/svg+xml">
+              </div>
               <span>{{question}}</span>
             </li>
             {{/each}}


### PR DESCRIPTION
Closes #70 

A couple of small changes were required in the normal styles, to ensure elements didn't fall outside of their defined height (thus being cut in half on page breaks). I've also extracted a duplicated height value to a CSS var. Other than that all styling is contained in a `@media print` block.

Note that the `-webkit-print-color-adjust` is specifically necessary, because Chrome doesn't respect the `print-color-adjust` property.