### PR TITLE
Added: Change look of the toggle details/summary button

### DIFF
--- a/src/content/en.json
+++ b/src/content/en.json
@@ -1,12 +1,16 @@
 {
   "utilityBar": {
-    "toggleTheme": "🌓 Toggle Dark / light theme",
-    "toggleView": "Expand / collapse details..."
+    "toggleTheme": "🌓 Toggle Dark / light theme"
   },
   "language": "🇬🇧 English",
   "description": "An overview of how we like to build software: which techniques and technology we like to use, and which principles we follow.",
   "header": {
     "subtitle": "At Infi we like to work the following way."
+  },
+  "toggleDetails": {
+    "expandAll": "Expand all",
+    "collapseAll": "Collapse all",
+    "expandCollapseDetails": "Expand / collapse details"
   },
   "test": {
     "title": "The Infi Test",

--- a/src/content/nl.json
+++ b/src/content/nl.json
@@ -1,12 +1,16 @@
 {
   "utilityBar": {
-    "toggleTheme": "🌓 Donker/Licht thema",
-    "toggleView": "Details in-/uitklappen..."
+    "toggleTheme": "🌓 Donker/Licht thema"
   },
   "language": "🇳🇱 Nederlands",
   "description": "Een overzicht van hoe wij graag software bouwen: welke technieken en technologie we graag gebruiken, en welke principes we volgen.",
   "header": {
     "subtitle": "Bij Infi werken we graag op de volgende manier"
+  },
+  "toggleDetails": {
+    "expandAll": "Uitklappen",
+    "collapseAll": "Inklappen",
+    "expandCollapseDetails": "Uit- of inklappen"
   },
   "test": {
     "title": "De Infi Test",

--- a/src/style.css
+++ b/src/style.css
@@ -507,13 +507,6 @@ h2:hover a .anchor-hint {
     display: block;
 }
 
-.view-summary .list-view div {
-    background: white;
-    border-radius: 1px;
-    width: 100%;
-    height: 5px;
-}
-
 .language-select {
     padding-top: 0.15rem;
     padding-right: 0.4rem;

--- a/src/style.css
+++ b/src/style.css
@@ -228,51 +228,6 @@ h2:hover a .anchor-hint {
     margin-bottom: 1rem;
 }
 
-.details-toggle {
-    position: absolute;
-    top: 20px;
-    right: 20px;
-    width: 2em;
-    height: 2em;
-    opacity: 0.5;
-    background: none !important;
-    padding: 0 !important;
-    font-size: inherit;
-    font-family: inherit;
-    cursor: pointer;
-    color: var(--color-text-light);
-    border: 2px solid var(--color-text-light);
-    border-radius: 50%;
-    text-align: center;
-    display: flex;
-}
-
-.details-toggle:hover {
-    opacity: 1;
-}
-
-.details-toggle:before {
-    content: '';
-    border: solid white;
-    border-width: 0 3px 3px 0;
-    display: inline-block;
-    padding: 3px;
-    margin: auto;
-    transform: rotate(-135deg);
-    -webkit-transform: rotate(-135deg);
-}
-
-.view-summary .details-toggle:before {
-    content: '';
-    border: solid white;
-    border-width: 0 3px 3px 0;
-    display: inline-block;
-    padding: 3px;
-    margin: auto;
-    transform: rotate(45deg);
-    -webkit-transform: rotate(45deg);
-}
-
 .block-image {
     margin: 2rem 0 0 calc(var(--block-image-height) / -2);
     border-radius: 50%;

--- a/src/style.css
+++ b/src/style.css
@@ -474,46 +474,25 @@ h2:hover a .anchor-hint {
 }
 
 .summary-toggle {
-    width: 1.5rem;
-    height: 1.5rem;
-    margin-top: 0.25rem;
-    opacity: 0.5;
     background: none;
     padding: 0 !important;
+    margin-right: 2rem;
     font-size: inherit;
     font-family: inherit;
     cursor: pointer;
     color: var(--color-text-light);
-    border: 2px solid var(--color-text-light);
-    border-radius: 8px;
-    text-align: center;
+    border: 0;
+    text-align: right;
 }
 
-.summary-toggle:hover {
-    background: var(--color-orange);
-    opacity: 1;
+.list-view, .grid-view {
+    text-decoration: underline;
+    text-decoration-thickness: 2px;
+    text-decoration-offset: 3px;
 }
 
-.summary-toggle:before {
-    display: block;
-    margin-top: -.25rem;
-}
-
-.summary-toggle .grid-view {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    grid-template-rows: 1fr 1fr;
-    gap: 0.3rem;
-    margin: 0 auto;
-    padding: .25rem;
-}
-
-.grid-view div {
-    background: white;
-    border-radius: 1px;
-    width: 5px;
-    height: 5px;
-    margin: 0 auto;
+.list-view:hover, .grid-view:hover {
+    text-decoration-style: double;
 }
 
 .summary-toggle .list-view {
@@ -525,10 +504,7 @@ h2:hover a .anchor-hint {
 }
 
 .view-summary .list-view {
-    display: flex;
-    flex-direction: column;
-    gap: 0.3rem;
-    padding: 0 .25rem;
+    display: block;
 }
 
 .view-summary .list-view div {

--- a/src/template.html
+++ b/src/template.html
@@ -103,13 +103,6 @@
                 <span class="anchor-hint">#</span>
               </a></h2>
               <p>{{topic.users.subtitle}}</p>
-                <button
-                  role="switch" class="details-toggle"
-                  data-toggle="users"
-                  aria-expanded="true"
-                  >
-                  <span class="sr-only">Details in-/uitklappen...</span>
-                </button>
             </section>
             <section class="details">
               <h3>{{topic.users.how-title}}</h3>
@@ -146,9 +139,6 @@
                 <span class="anchor-hint">#</span>
               </a></h2>
               <p>{{topic.principles.subtitle}}</p>
-              <button class="details-toggle" data-toggle="principles" aria-expanded="true">
-                <span class="sr-only">Details in-/uitklappen...</span>
-              </button>
             </section>
             <section class="details">
               <h3>{{topic.principles.how-title}}</h3>
@@ -185,9 +175,6 @@
                 <span class="anchor-hint">#</span>
               </a></h2>
               <p>{{topic.source-code.subtitle}}</p>
-              <button class="details-toggle" data-toggle="source-code" aria-expanded="true">
-                <span class="sr-only">Details in-/uitklappen...</span>
-              </button>
             </section>
             <section class="details">
               <h3>{{topic.source-code.how-title}}</h3>
@@ -224,9 +211,6 @@
                 <span class="anchor-hint">#</span>
               </a></h2>
               <p>{{topic.technology.subtitle}}</p>
-              <button class="details-toggle" data-toggle="technology" aria-expanded="true">
-                <span class="sr-only">Details in-/uitklappen...</span>
-              </button>
             </section>
             <section class="details">
               <h3>{{topic.technology.how-title}}</h3>
@@ -263,9 +247,6 @@
                 <span class="anchor-hint">#</span>
               </a></h2>
               <p>{{topic.process-and-team.subtitle}}</p>
-              <button class="details-toggle" data-toggle="process-and-team" aria-expanded="true">
-                <span class="sr-only">Details in-/uitklappen...</span>
-              </button>
             </section>
             <section class="details">
               <h3>{{topic.process-and-team.how-title}}</h3>
@@ -302,9 +283,6 @@
                 <span class="anchor-hint">#</span>
               </a></h2>
               <p>{{topic.craft.subtitle}}</p>
-              <button class="details-toggle" data-toggle="craft" aria-expanded="true">
-                <span class="sr-only">Details in-/uitklappen...</span>
-              </button>
             </section>
             <section class="details">
               <h3>{{topic.craft.how-title}}</h3>
@@ -341,9 +319,6 @@
                 <span class="anchor-hint">#</span>
               </a></h2>
               <p>{{topic.others.subtitle}}</p>
-              <button class="details-toggle" data-toggle="others" aria-expanded="true">
-                <span class="sr-only">Details in-/uitklappen...</span>
-              </button>
             </section>
             <section class="details">
               <h3>{{topic.others.how-title}}</h3>
@@ -424,11 +399,6 @@
 
         themeToggleButton.addEventListener('click', toggleLightMode);
         summaryToggleButton.addEventListener('click', toggleDetailView);
-
-        const detailTogglers = document.querySelectorAll('[class="details-toggle"]');
-        detailTogglers.forEach(button => {
-          button.addEventListener('click', () => toggleTopic(button.getAttribute('data-toggle')))
-        });
       });
 
       function toggleLightMode() {
@@ -469,51 +439,6 @@
           url.searchParams.delete('summary');
         } else {
           url.searchParams.set('summary', 'true');
-        }
-
-        window.history.replaceState({}, '', url);
-      }
-
-      function toggleTopic(topic) {
-        const button = document.querySelector(`.topic-${topic} button`);
-        const viewState = button.getAttribute('aria-expanded') === 'true';
-
-        button.setAttribute('aria-expanded', viewState ? 'false' : 'true');
-        button.classList.toggle('view-summary');
-        const target = document.querySelector(`.block.topic-${topic}`);
-        target.classList.toggle('view-summary');
-
-        checkSummaryState();
-      }
-
-      function checkSummaryState() {
-        const blocks = document.querySelectorAll('.block');
-        const states = Array.from(blocks).map(block => block.classList.contains('view-summary'));
-
-        if (states.includes(true) && states.includes(false)) {
-          return;
-        }
-        if (states.includes(true)) {
-          setButtonState(true);
-        } else {
-          setButtonState(false);
-        }
-      }
-
-      function setButtonState(state) {
-        const button = document.querySelector('[data-toggle="summary"]');
-        if (state)
-          button.classList.add('view-summary');
-        else
-          button.classList.remove('view-summary');
-        button.setAttribute('aria-expanded', !state ? 'true' : 'false');
-
-        const url = new URL(window.location.href);
-
-        if (state) {
-          url.searchParams.set('summary', 'true');
-        } else {
-          url.searchParams.delete('summary');
         }
 
         window.history.replaceState({}, '', url);

--- a/src/template.html
+++ b/src/template.html
@@ -83,14 +83,10 @@
               aria-expanded="true"
             >
               <div class="grid-view">
-                <div></div>
-                <div></div>
-                <div></div>
-                <div></div>
+                Collapse all
               </div>
               <div class="list-view">
-                <div></div>
-                <div></div>
+                Expand all
               </div>
               <span class="sr-only">{{utilityBar.toggleView}}</span>
             </button>

--- a/src/template.html
+++ b/src/template.html
@@ -80,7 +80,7 @@
               data-toggle="summary"
               role="switch"
               aria-label="{{utilityBar.toggleView}}"
-              aria-expanded="true"
+              aria-checked="true"
             >
               <div class="grid-view">
                 Collapse all
@@ -419,7 +419,7 @@
           blocks.forEach(block => {
             block.classList.toggle('view-summary');
           })
-          summaryToggleButton.setAttribute('aria-expanded', 'false');
+          summaryToggleButton.setAttribute('aria-checked', 'false');
         }
 
         themeToggleButton.addEventListener('click', toggleLightMode);
@@ -451,8 +451,8 @@
         const button = document.querySelector('[data-toggle="summary"]');
         button.classList.toggle('view-summary');
 
-        const buttonState = button.getAttribute('aria-expanded') === 'true';
-        button.setAttribute('aria-expanded', button.getAttribute('aria-expanded') === 'true' ? 'false' : 'true');
+        const buttonState = button.getAttribute('aria-checked') === 'true';
+        button.setAttribute('aria-checked', button.getAttribute('aria-checked') === 'true' ? 'false' : 'true');
 
         const blocks = document.querySelectorAll('.block');
         blocks.forEach(block => {

--- a/src/template.html
+++ b/src/template.html
@@ -75,20 +75,20 @@
       <section class="blocks">
         <nav class="blocks-bar">
             <button
-              title="{{utilityBar.toggleView}}"
+              title="{{toggleDetails.expandCollapseDetails}}"
               class="summary-toggle"
               data-toggle="summary"
               role="switch"
-              aria-label="{{utilityBar.toggleView}}"
+              aria-label="{{toggleDetails.expandCollapseDetails}}"
               aria-checked="true"
             >
               <div class="grid-view">
-                Collapse all
+                {{toggleDetails.collapseAll}}
               </div>
               <div class="list-view">
-                Expand all
+                {{toggleDetails.expandAll}}
               </div>
-              <span class="sr-only">{{utilityBar.toggleView}}</span>
+              <span class="sr-only">{{toggleDetails.expandCollapseDetails}}</span>
             </button>
         </nav>
         <div class="block topic-users">

--- a/src/template.html
+++ b/src/template.html
@@ -395,6 +395,7 @@
             block.classList.toggle('view-summary');
           })
           summaryToggleButton.setAttribute('aria-checked', 'false');
+          summaryToggleButton.classList.toggle('view-summary');
         }
 
         themeToggleButton.addEventListener('click', toggleLightMode);


### PR DESCRIPTION
This PR replaces the grid/list "icons" by plain text, which should be better readable by a screen reader and possibly also makes it clearer in general. Additionally, it removes the individual toggle section icon buttons.

Related to #86 